### PR TITLE
Fix checkIntersection issue

### DIFF
--- a/src/jqplot.core.js
+++ b/src/jqplot.core.js
@@ -3243,7 +3243,7 @@
                         for (j=0; j<s._barPoints.length; j++) {
                             points = s._barPoints[j];
                             p = s.gridData[j];
-                            if (x>points[0][0] && x<points[2][0] && y>points[2][1] && y<points[0][1]) {
+                            if (x>points[0][0] && x<points[2][0] && (y>points[2][1] && y<points[0][1] || y<points[2][1] && y>points[0][1])) {
                                 return {seriesIndex:s.index, pointIndex:j, gridData:p, data:s.data[j], points:s._barPoints[j]};
                             }
                         }


### PR DESCRIPTION
The function `checkIntersection(gridpos, plot)` does not return an intersection for **negative** values in a waterfall plot. 

Specifically this plot: 
```javascript
renderer:$.jqplot.BarRenderer, rendererOptions:{waterfall:true} 
```

The fault impacts the use of the highlight plugin and mouse event handlers which rely on the checkIntersection function to return the intersection of the mouse cursor and bar. There are likely other impacts too.

The fault exists in inside 
```javascript
function checkIntersection(gridpos, plot)
```

:gem: **See the issue  #7  for more details**