### PR TITLE
Fixing infinite loop

### DIFF
--- a/src/jqplot.toImage.js
+++ b/src/jqplot.toImage.js
@@ -181,7 +181,7 @@
 
             for (var i=0; i<wl; i++) {
                 w += words[i];
-                if (context.measureText(w).width > tagwidth) {
+                if (context.measureText(w).width > tagwidth && w.length > words[i].length) {
                     breaks.push(i);
                     w = '';
                     i--;


### PR DESCRIPTION
Hi,

I have a problem when converting my jqPlot image to an image, resulting in an infinite loop and making it impossible to make use of this functionality.
 
After some Googling I found the solution of  Edward Faulkner (https://bitbucket.org/ef4/jqplot/commits/a59e7e7a5e97ea721a7b8571612b334e8c025b36) which works for me (and other apparently).
But for some reason his pull request never made it (got lost in the transition to GitHub?)

Hence this Pull Request to actually include his fix after all.

What it does, is check if the w consists of more words than the current word. If not, it is not possible to break before the current word as it does not fit the available space (tagWidth). And breaking should be skipped.

As a result this fixes the 'infinite loop' issue.

Cheers,
  Maarten