### PR TITLE
new "totalLabel" rendererOption for donut renderer

### DIFF
--- a/examples/pie-donut-charts.php
+++ b/examples/pie-donut-charts.php
@@ -30,7 +30,13 @@
 <div id="chart3" style="height:300px; width:500px;"></div>
 
 <pre class="code prettyprint brush: js"></pre>
-  
+
+<p>For donuts you can fill the empty space in the centre with useful total sum information.</p>
+
+<div id="chart4" style="height:300px; width:500px;"></div>
+
+<pre class="code prettyprint brush: js"></pre>
+
 <script class="code" type="text/javascript">
 $(document).ready(function(){
   var data = [
@@ -99,6 +105,34 @@ $(document).ready(function(){
         // By default, data labels show the percentage of the donut/pie.
         // You can show the data 'value' or data 'label' instead.
         dataLabels: 'value'
+      }
+    }
+  });
+});
+</script>
+
+<script class="code" type="text/javascript">
+$(document).ready(function(){
+  var data = [
+    ['Heavy Industry', 12],['Retail', 9], ['Light Industry', 14], 
+    ['Out of home', 16],['Commuting', 7], ['Orientation', 9]
+  ];
+  
+  var plot4 = $.jqplot('chart4', [data], {
+    seriesDefaults: {
+      // make this a donut chart.
+      renderer:$.jqplot.DonutRenderer,
+      rendererOptions:{
+        // Donut's can be cut into slices like pies.
+        sliceMargin: 3,
+        // Pies and donuts can start at any arbitrary angle.
+        startAngle: -90,
+        showDataLabels: true,
+        // By default, data labels show the percentage of the donut/pie.
+        // You can show the data 'value' or data 'label' instead.
+        dataLabels: 'value'
+        // "totalLabel=true" uses the centre of the donut for the total amount
+        totalLabel: true;
       }
     }
   });

--- a/examples/pie-donut-charts.php
+++ b/examples/pie-donut-charts.php
@@ -130,9 +130,9 @@ $(document).ready(function(){
         showDataLabels: true,
         // By default, data labels show the percentage of the donut/pie.
         // You can show the data 'value' or data 'label' instead.
-        dataLabels: 'value'
+        dataLabels: 'value',
         // "totalLabel=true" uses the centre of the donut for the total amount
-        totalLabel: true;
+        totalLabel: true
       }
     }
   });

--- a/src/plugins/jqplot.donutRenderer.js
+++ b/src/plugins/jqplot.donutRenderer.js
@@ -132,6 +132,9 @@
         // prop: showDataLabels
         // true to show data labels on slices.
         this.showDataLabels = false;
+        // prop: totalLabel
+        // true to show total label in the centre
+        this.totalLabel = false;
         // prop: dataLabelFormatString
         // Format string for data labels.  If none, '%s' is used for "label" and for arrays, '%d' for value and '%d%%' for percentage.
         this.dataLabelFormatString = null;
@@ -263,6 +266,7 @@
             td[i][1] = stack[i] * fact;
             td[i][2] = data[i][1]/tot;
         }
+        this._totalAmount = tot;        
         return td;
     };
     
@@ -450,7 +454,10 @@
                 labelelem.css({left: x, top: y});
             }
         }
-               
+        if (this.totalLabel) {
+            var totalLabel = $('<div class="jqplot-data-label" style="position:absolute">' + this._totalAmount + '</div>').insertAfter(plot.eventCanvas._elem);
+            totalLabel.css({left: this._center[0], top: this._center[1]});
+        }
     };
     
     $.jqplot.DonutAxisRenderer = function() {


### PR DESCRIPTION
introduce "totalLabel" rendererOption for donut render to display the total amount of items in the center of the donut

Result looks like this:
![total_amount_donut](https://cloud.githubusercontent.com/assets/7577275/10633133/0ea3f664-77e9-11e5-938b-21666cb2029a.png)