### PR TITLE
Update jqplot.pointLabels.js

### DIFF
--- a/src/plugins/jqplot.pointLabels.js
+++ b/src/plugins/jqplot.pointLabels.js
@@ -294,7 +294,7 @@
             for (var i=0, l=p._labels.length; i < l; i++) {
                 var label = p._labels[i];
                 
-                if (label == null || (p.hideZeros && parseInt(label, 10) == 0)) {
+                if (label == null || (p.hideZeros && parseFloat(label) == 0)) {
                     continue;
                 }
                 


### PR DESCRIPTION
Instead of  using "parseInt(label, 10)" I suggest to use "parseFloat(label)" in this case so that decimals such as "0.002" or "0.312" are also rendered