### PR TITLE
Update jqplot.pieRenderer.js

### DIFF
--- a/src/plugins/jqplot.pieRenderer.js
+++ b/src/plugins/jqplot.pieRenderer.js
@@ -395,8 +395,12 @@
         
         var shadow = (opts.shadow != undefined) ? opts.shadow : this.shadow;
         var fill = (opts.fill != undefined) ? opts.fill : this.fill;
-        var cw = ctx.canvas.width;
-        var ch = ctx.canvas.height;
+        
+        //see http://stackoverflow.com/questions/20221461/hidpi-retina-plot-drawing
+        var cw = parseInt(ctx.canvas.style.width);
+        var ch = parseInt(ctx.canvas.style.height);
+        //
+        
         var w = cw - offx - 2 * this.padding;
         var h = ch - offy - 2 * this.padding;
         var mindim = Math.min(w,h);


### PR DESCRIPTION
This change adds support for highdpi displays (e.g. retina) for pie charts