### PR TITLE
Error resizing horizontal bar charts

### DIFF
--- a/src/plugins/jqplot.pointLabels.js
+++ b/src/plugins/jqplot.pointLabels.js
@@ -273,7 +273,7 @@
         for (var i=0; i<p._elems.length; i++) {
             // Memory Leaks patch
             // p._elems[i].remove();
-            p._elems[i].emptyForce();
+            if(p._elems[i]) p._elems[i].emptyForce();
         }
         p._elems.splice(0, p._elems.length);
 

--- a/src/plugins/jqplot.pointLabels.js
+++ b/src/plugins/jqplot.pointLabels.js
@@ -273,7 +273,9 @@
         for (var i=0; i<p._elems.length; i++) {
             // Memory Leaks patch
             // p._elems[i].remove();
-            if(p._elems[i]) p._elems[i].emptyForce();
+            if(p._elems[i]) {
+                p._elems[i].emptyForce();
+            }
         }
         p._elems.splice(0, p._elems.length);
 


### PR DESCRIPTION
Fixes JS-error on resizing for horizontal bar charts which have the option pointLables->hideZeros to true