### PR TITLE
Patch 1

### DIFF
--- a/src/plugins/jqplot.donutRenderer.js
+++ b/src/plugins/jqplot.donutRenderer.js
@@ -393,7 +393,10 @@
         else {
             this._thickness = this.thickness || mindim / 2 / (this._numberSeries + 1) * 0.85;
         }
-
+        if (this._diameter < 6) {
+            $.jqplot.log("Diameter of donut too small, not rendering.");
+            return;
+        }
         var r = this._radius = this._diameter/2;
         this._innerRadius = this._radius - this._thickness;
         var sa = this.startAngle / 180 * Math.PI;


### PR DESCRIPTION
Problem -
Unlike Pie Renderer, in case of donut Renderer there is no check to see if diameter of donut is too small. This is causing IndexSizeError.  
Proposed Change - 
Added a check to see if diameter is less than 6 (just like Pie Render) into Donut Renderer js file.

Note:- Change showing at end of the file is probably due to browser as I checked code using browser, I tried removing it in second edit but it was not removed.