### PR TITLE
fix for #38 (pie charts not rendering because of highres support)

### DIFF
--- a/src/jqplot.core.js
+++ b/src/jqplot.core.js
@@ -295,6 +295,25 @@
             if ($.jqplot.use_excanvas) {
                 return window.G_vmlCanvasManager.initElement(canvas);
             }
+
+            var cctx = canvas.getContext('2d');
+
+            var canvasBackingScale = 1;
+            if (window.devicePixelRatio > 1 && (cctx.webkitBackingStorePixelRatio === undefined || 
+                                                cctx.webkitBackingStorePixelRatio < 2)) {
+                canvasBackingScale = window.devicePixelRatio;
+            }
+            var oldWidth = canvas.width;
+            var oldHeight = canvas.height;
+
+            canvas.width = canvasBackingScale * canvas.width;
+            canvas.height = canvasBackingScale * canvas.height;
+            canvas.style.width = oldWidth + 'px';
+            canvas.style.height = oldHeight + 'px';
+            cctx.save();
+
+            cctx.scale(canvasBackingScale, canvasBackingScale);
+
             return canvas;
         };
 


### PR DESCRIPTION
added missing code from http://stackoverflow.com/questions/20221461/hidpi-retina-plot-drawing to jqplot.core.js because high resolution support is broken without that. Fix for #38.