### PR TITLE
fix for #47 (donut charts not rendering correctly because of highres support)

### DIFF
--- a/src/plugins/jqplot.donutRenderer.js
+++ b/src/plugins/jqplot.donutRenderer.js
@@ -378,8 +378,9 @@
         var shadow = (opts.shadow != undefined) ? opts.shadow : this.shadow;
         var showLine = (opts.showLine != undefined) ? opts.showLine : this.showLine;
         var fill = (opts.fill != undefined) ? opts.fill : this.fill;
-        var cw = ctx.canvas.width;
-        var ch = ctx.canvas.height;
+        //see http://stackoverflow.com/questions/20221461/hidpi-retina-plot-drawing
+        var cw = parseInt(ctx.canvas.style.width);
+        var ch = parseInt(ctx.canvas.style.height);
         var w = cw - offx - 2 * this.padding;
         var h = ch - offy - 2 * this.padding;
         var mindim = Math.min(w,h);


### PR DESCRIPTION
canvas.style.width and canvas.style.height must be used instead of canvas.width and canvas.height