### PR TITLE
The highlighter point is always on the middle of a set of bars when using multiple bar series

### DIFF
--- a/examples/barChartHightlighter.php
+++ b/examples/barChartHightlighter.php
@@ -1,0 +1,75 @@
+<?php 
+    $title = "Bar Charts with Highlighter";
+    // $plotTargets = array(array('id'=>'chart1', 'height'=>300, 'width'=>700));
+?>
+<?php include "opener.php"; ?>
+
+<!-- Example scripts go here -->
+
+
+    <p>These are two bar charts with highlighter enabled. Hovering the mouse over a bar should show a dot at the top of the bar, at the point representing the value.<p>
+    
+    <div id="chart1" style="margin-top:20px; margin-left:20px; width:300px; height:300px;"></div>
+<pre class="code brush:js"></pre>
+    
+    <div id="chart2" style="margin-top:20px; margin-left:20px; width:300px; height:300px;"></div>
+<pre class="code brush:js"></pre>
+    
+
+    
+  <script class="code" type="text/javascript">$(document).ready(function(){
+        var s1 = [2, 6, 7, 10];
+        var s2 = [7, 5, 3, 2];
+        var ticks = ['a', 'b', 'c', 'd'];
+        
+        plot1 = $.jqplot('chart1', [s1, s2], {
+            seriesDefaults: {
+                renderer:$.jqplot.BarRenderer
+            },
+            axes: {
+                xaxis: {
+                    renderer: $.jqplot.CategoryAxisRenderer,
+                    ticks: ticks
+                }
+            },
+            highlighter: {
+                show: true
+            }
+        });
+    });</script>
+    
+  <script class="code" type="text/javascript">$(document).ready(function(){
+        plot2 = $.jqplot('chart2', [[[2,1], [4,2], [6,3], [3,4]], [[5,1], [1,2], [3,3], [4,4]], [[4,1], [7,2], [1,3], [2,4]]], {
+            seriesDefaults: {
+                renderer:$.jqplot.BarRenderer,
+                shadowAngle: 135,
+                rendererOptions: {
+                    barDirection: 'horizontal'
+                }
+            },
+            axes: {
+                yaxis: {
+                    renderer: $.jqplot.CategoryAxisRenderer
+                }
+            },
+            highlighter: {
+                show: true
+            }
+        });
+    });</script>
+<!-- End example scripts -->
+
+<!-- Don't touch this! -->
+
+<?php include "commonScripts.html" ?>
+
+<!-- Additional plugins go here -->
+
+  <script class="include" type="text/javascript" src="../src/plugins/jqplot.barRenderer.js"></script>
+  <script class="include" type="text/javascript" src="../src/plugins/jqplot.pieRenderer.js"></script>
+  <script class="include" type="text/javascript" src="../src/plugins/jqplot.categoryAxisRenderer.js"></script>
+  <script class="include" type="text/javascript" src="../src/plugins/jqplot.highlighter.js"></script>
+
+<!-- End additional plugins -->
+
+<?php include "closer.php"; ?>

--- a/src/plugins/jqplot.highlighter.js
+++ b/src/plugins/jqplot.highlighter.js
@@ -223,7 +223,18 @@
         var alpha = (rgba[3] >= 0.6) ? rgba[3]*0.6 : rgba[3]*(2-rgba[3]);
         mr.color = 'rgba('+newrgb[0]+','+newrgb[1]+','+newrgb[2]+','+alpha+')';
         mr.init();
-        mr.draw(s.gridData[neighbor.pointIndex][0], s.gridData[neighbor.pointIndex][1], hl.highlightCanvas._ctx);
+        var x_pos = s.gridData[neighbor.pointIndex][0];
+        var y_pos = s.gridData[neighbor.pointIndex][1];
+        // Adjusting with s._barNudge
+        if (s.renderer.constructor == $.jqplot.BarRenderer) {
+            if (s.barDirection == "vertical") {
+                x_pos += s._barNudge;
+            }
+            else {
+                y_pos -= s._barNudge;
+            }
+        }
+        mr.draw(x_pos, y_pos, hl.highlightCanvas._ctx);
     }
     
     function showTooltip(plot, series, neighbor) {
@@ -383,6 +394,14 @@
                 var y = gridpos.y + plot._gridPadding.top - opts.tooltipOffset - elem.outerHeight(true) - fact * ms;
                 break;
         }
+        if (series.renderer.constructor == $.jqplot.BarRenderer) {        
+    	    if (series.barDirection == 'vertical') {                        
+    	        x += series._barNudge;
+    	    }
+    	    else {                                                          
+    	        y -= series._barNudge;
+    	    } 
+    	}
         elem.css('left', x);
         elem.css('top', y);
         if (opts.fadeTooltip) {


### PR DESCRIPTION
This is a fix for the same problem as reported in this old issue: https://bitbucket.org/cleonello/jqplot/issues/514 (and this pull request: https://bitbucket.org/cleonello/jqplot/pull-requests/22/fix-for-issue-514-adjusting-position-with/diff )

When using the bar renderer and the highlighter, with multiple bars, the marker shown by the highlighter appears at the correct Y coordinate (when using vertical bars) but the X coordinate value is always at the middle of the category (that is at the middle of all the bars within a given category), irrespectively of which bar/value is supposed to be highlighted.

This pull requests adds a first patch with a new example illustrating the problem. The second patch suggests a fix.


![jqplot-pr-59](https://cloud.githubusercontent.com/assets/80994/13380502/2f32aa14-de3d-11e5-9104-9f6a85a1913c.png)