### PR TITLE
Ability to customise individual point markers within a series

### DIFF
--- a/examples/line-charts-variable-markers.php
+++ b/examples/line-charts-variable-markers.php
@@ -1,0 +1,177 @@
+<?php 
+    $title = "Line Charts and Options - Variable Markers";
+    // $plotTargets = array (array('id'=>'chart1', 'width'=>600, 'height'=>400));
+?>
+<?php include "opener.php"; ?>
+
+<!-- Example scripts go here -->
+
+<p>There are numerous line style options to control how the lines and markers are displayed.</p>
+
+<div id="chart1" style="height:300px; width:500px;"></div>
+
+<pre class="code prettyprint brush: js"></pre>
+
+
+<p>The following example shows how to control marker options depending on the data point, using the markerOptionsCallback.</p>
+
+<div id="chart2" style="height:300px; width:500px;"></div>
+
+<pre class="code prettyprint brush: js"></pre>
+
+<script type="text/javascript">
+var cosPoints = [];
+var sinPoints = []; 
+var powPoints1 = [];
+var powPoints2 = []; 
+$(document).ready(function(){
+  // Some simple loops to build up data arrays.
+  for (var i=0; i<2*Math.PI; i+=1){ 
+    cosPoints.push([i, Math.cos(i)]); 
+  }
+   
+  for (var i=0; i<2*Math.PI; i+=0.4){ 
+     sinPoints.push([i, 2*Math.sin(i-.8)]); 
+  }
+    
+  for (var i=0; i<2*Math.PI; i+=1) { 
+      powPoints1.push([i, 2.5 + Math.pow(i/4, 2)]); 
+  }
+   
+  for (var i=0; i<2*Math.PI; i+=1) { 
+      powPoints2.push([i, -2.5 - Math.pow(i/4, 2)]); 
+  }
+});
+</script>
+  
+<script class="code" type="text/javascript">
+$(document).ready(function(){
+  var plot1 = $.jqplot('chart1', [cosPoints, sinPoints, powPoints1, powPoints2], 
+    { 
+      title:'Line Style Options', 
+      // Set default options on all series, turn on smoothing.
+      seriesDefaults: {
+          rendererOptions: {
+              smooth: true
+          }
+      },
+      // Series options are specified as an array of objects, one object
+      // for each series.
+      series:[ 
+          {
+            // Change our line width and use a diamond shaped marker.
+            lineWidth:2, 
+            markerOptions: { style:'circle' }
+          }, 
+          {
+            // Don't show a line, just show markers.
+            // Make the markers 7 pixels with an 'x' style
+            showLine:false, 
+            markerOptions: { size: 7, style:"x" }
+          },
+          { 
+            // Use (open) circlular markers.
+            markerOptions: { size:20, style:"diamond" }
+          }, 
+          {
+            // Use a thicker, 5 pixel line and 10 pixel
+            // filled square markers.
+            lineWidth:5, 
+            markerOptions: { style:"filledSquare", size:10 }
+          }
+      ]
+    }
+  );
+   
+});
+</script>
+  
+<script class="code" type="text/javascript">
+$(document).ready(function(){
+  var plot2 = $.jqplot('chart2', [cosPoints, sinPoints, powPoints1, powPoints2], 
+    { 
+      title:'Line Style Options', 
+      // Set default options on all series, turn on smoothing.
+      seriesDefaults: {
+          rendererOptions: {
+              smooth: true
+          }
+      },
+      // Series options are specified as an array of objects, one object
+      // for each series.
+      series:[ 
+          {
+            // Change our line width and use a diamond shaped marker.
+            lineWidth:2, 
+            markerOptions: { style:'circle' },
+            markerOptionsCallback: function(plot, series, idx, dataPoint, gridDataPoint) {
+                var opts =  {};
+                if (dataPoint[1] < 0) {
+                    opts.color = "red";
+                }
+                return opts;
+            }
+          }, 
+          {
+            // Don't show a line, just show markers.
+            // Make the markers 7 pixels with an 'x' style
+            showLine:false, 
+            markerOptions: { size: 7, style:"x" },
+            markerOptionsCallback: function(plot, series, idx, dataPoint, gridDataPoint) {
+                var opts =  { style:"diamond" };
+                if (dataPoint[1] < 0) {
+                    opts.color = "red";
+                }
+                return opts;
+            }
+          },
+          { 
+            // Use (open) circlular markers.
+            markerOptions: { size: 20 , style:"circle" },
+            markerOptionsCallback: function(plot, series, idx, dataPoint, gridDataPoint) {
+                if (idx < 2) {
+                    return { style:"square" };
+                } else if (idx < 4) {
+                    return { style:"diamond" };
+                } else if (idx < 5) {
+                    return { style: "filledDiamond", color: "blue" };
+                }
+            }
+          }, 
+          {
+            // Use a thicker, 5 pixel line and 10 pixel
+            // filled square markers.
+            lineWidth:5, 
+            markerOptions: { style:"filledSquare", size:10 },
+            markerOptionsCallback: function(plot, series, idx, dataPoint, gridDataPoint) {
+                var opts =  {};
+                if (dataPoint[0] >3) {
+                    opts.color = "yellow";
+                }
+                return opts;
+            }
+          }
+      ]
+    }
+  );
+   
+});
+</script>
+
+
+<!-- End example scripts -->
+
+<!-- Don't touch this! -->
+
+<?php include "commonScripts.html" ?>
+
+<!-- End Don't touch this! -->
+
+<!-- Additional plugins go here -->
+
+  <script class="include" type="text/javascript" src="../src/plugins/jqplot.canvasTextRenderer.js"></script>
+  <script class="include" type="text/javascript" src="../src/plugins/jqplot.canvasAxisLabelRenderer.js"></script>
+
+<!-- End additional plugins -->
+
+<?php include "closer.php"; ?>

--- a/src/jqplot.lineRenderer.js
+++ b/src/jqplot.lineRenderer.js
@@ -1014,7 +1014,11 @@
                                 fasgd = this.gridData;
                             }
                             for (i=0; i<fasgd.length; i++) {
-                                this.markerRenderer.draw(fasgd[i][0], fasgd[i][1], ctx, opts.markerOptions);
+                                var markerOptions = opts.markerOptions || {};
+                                if (this.markerOptionsCallback) {
+                                    markerOptions = $.extend(true, markerOptions, this.markerOptionsCallback(plot, this, i, this.data[i], gd[i]) || {});
+                                }
+                                this.markerRenderer.draw(fasgd[i][0], fasgd[i][1], ctx, markerOptions);
                             }
                         }
                     }
@@ -1084,8 +1088,12 @@
                     gd = this.gridData;
                 }
                 for (i=0; i<gd.length; i++) {
+                    var markerOptions = opts.markerOptions || {};
+                    if (this.markerOptionsCallback) {
+                        markerOptions = $.extend(true, markerOptions, this.markerOptionsCallback(plot, this, i, this.data[i], gd[i]) || {});
+                    }
                     if (gd[i][0] != null && gd[i][1] != null) {
-                        this.markerRenderer.draw(gd[i][0], gd[i][1], ctx, opts.markerOptions);
+                        this.markerRenderer.draw(gd[i][0], gd[i][1], ctx, markerOptions);
                     }
                 }
             }

--- a/src/jqplot.markerRenderer.js
+++ b/src/jqplot.markerRenderer.js
@@ -74,108 +74,143 @@
         $.extend(true, this, options);
     };
     
-    $.jqplot.MarkerRenderer.prototype.init = function(options) {
-        $.extend(true, this, options);
-        var sdopt = {angle:this.shadowAngle, offset:this.shadowOffset, alpha:this.shadowAlpha, lineWidth:this.lineWidth, depth:this.shadowDepth, closePath:true};
-        if (this.style.indexOf('filled') != -1) {
+    function getShadowRendererOptions(opts) {
+        var sdopt = {angle:opts.shadowAngle, offset:opts.shadowOffset, alpha:opts.shadowAlpha, lineWidth:opts.lineWidth, depth:opts.shadowDepth, closePath:true};
+        if (opts.style.indexOf('filled') != -1) {
             sdopt.fill = true;
         }
-        if (this.style.indexOf('ircle') != -1) {
+        if (opts.style.indexOf('ircle') != -1) {
             sdopt.isarc = true;
             sdopt.closePath = false;
         }
-        this.shadowRenderer.init(sdopt);
-        
-        var shopt = {fill:false, isarc:false, strokeStyle:this.color, fillStyle:this.color, lineWidth:this.lineWidth, closePath:true};
-        if (this.style.indexOf('filled') != -1) {
+        return $.extend(true, {}, sdopt);
+    }
+    
+    function getShapeRendererOptions(opts) {
+        var shopt = {fill:false, isarc:false, strokeStyle:opts.color, fillStyle:opts.color, lineWidth:opts.lineWidth, closePath:true};
+        if (opts.style.indexOf('filled') != -1) {
             shopt.fill = true;
         }
-        if (this.style.indexOf('ircle') != -1) {
+        if (opts.style.indexOf('ircle') != -1) {
             shopt.isarc = true;
             shopt.closePath = false;
         }
-        this.shapeRenderer.init(shopt);
+        return $.extend(true, {}, shopt);
+    }
+    
+    $.jqplot.MarkerRenderer.prototype.init = function(options) {
+        $.extend(true, this, options);
     };
     
     $.jqplot.MarkerRenderer.prototype.drawDiamond = function(x, y, ctx, fill, options) {
+        var opts;
+        if (options == null || $.isEmptyObject(options)) {
+            opts = this;
+        } else {
+            opts = $.extend(true, {}, this, options);
+        }
         var stretch = 1.2;
         var dx = this.size/2/stretch;
         var dy = this.size/2*stretch;
         var points = [[x-dx, y], [x, y+dy], [x+dx, y], [x, y-dy]];
-        if (this.shadow) {
-            this.shadowRenderer.draw(ctx, points);
+        if (opts.shadow) {
+            this.shadowRenderer.draw(ctx, points, getShadowRendererOptions(opts));
         }
-        this.shapeRenderer.draw(ctx, points, options);
+        this.shapeRenderer.draw(ctx, points, getShapeRendererOptions(opts));
     };
     
     $.jqplot.MarkerRenderer.prototype.drawPlus = function(x, y, ctx, fill, options) {
+        var opts = $.extend(true, {}, this, options, {closePath:false});
         var stretch = 1.0;
-        var dx = this.size/2*stretch;
-        var dy = this.size/2*stretch;
+        var dx = opts.size/2*stretch;
+        var dy = opts.size/2*stretch;
         var points1 = [[x, y-dy], [x, y+dy]];
         var points2 = [[x+dx, y], [x-dx, y]];
-        var opts = $.extend(true, {}, this.options, {closePath:false});
-        if (this.shadow) {
-            this.shadowRenderer.draw(ctx, points1, {closePath:false});
-            this.shadowRenderer.draw(ctx, points2, {closePath:false});
+        if (opts.shadow) {
+            this.shadowRenderer.draw(ctx, points1, getShadowRendererOptions(opts));
+            this.shadowRenderer.draw(ctx, points2, getShadowRendererOptions(opts));
         }
         this.shapeRenderer.draw(ctx, points1, opts);
         this.shapeRenderer.draw(ctx, points2, opts);
     };
     
     $.jqplot.MarkerRenderer.prototype.drawX = function(x, y, ctx, fill, options) {
+        var opts = $.extend(true, {}, this, options, {closePath:false});
         var stretch = 1.0;
-        var dx = this.size/2*stretch;
-        var dy = this.size/2*stretch;
-        var opts = $.extend(true, {}, this.options, {closePath:false});
+        var dx = opts.size/2*stretch;
+        var dy = opts.size/2*stretch;
         var points1 = [[x-dx, y-dy], [x+dx, y+dy]];
         var points2 = [[x-dx, y+dy], [x+dx, y-dy]];
-        if (this.shadow) {
-            this.shadowRenderer.draw(ctx, points1, {closePath:false});
-            this.shadowRenderer.draw(ctx, points2, {closePath:false});
+        if (opts.shadow) {
+            this.shadowRenderer.draw(ctx, points1, getShadowRendererOptions(opts));
+            this.shadowRenderer.draw(ctx, points2, getShadowRendererOptions(opts));
         }
-        this.shapeRenderer.draw(ctx, points1, opts);
-        this.shapeRenderer.draw(ctx, points2, opts);
+        this.shapeRenderer.draw(ctx, points1, getShapeRendererOptions(opts));
+        this.shapeRenderer.draw(ctx, points2, getShapeRendererOptions(opts));
     };
     
     $.jqplot.MarkerRenderer.prototype.drawDash = function(x, y, ctx, fill, options) {
+        var opts;
+        if (options == null || $.isEmptyObject(options)) {
+            opts = this;
+        } else {
+            opts = $.extend(true, {}, this, options);
+        }
         var stretch = 1.0;
         var dx = this.size/2*stretch;
         var dy = this.size/2*stretch;
         var points = [[x-dx, y], [x+dx, y]];
-        if (this.shadow) {
+        if (opts.shadow) {
             this.shadowRenderer.draw(ctx, points);
         }
-        this.shapeRenderer.draw(ctx, points, options);
+        this.shapeRenderer.draw(ctx, points, getShapeRendererOptions(opts));
     };
     
     $.jqplot.MarkerRenderer.prototype.drawLine = function(p1, p2, ctx, fill, options) {
-        var points = [p1, p2];
-        if (this.shadow) {
-            this.shadowRenderer.draw(ctx, points);
+        var opts;
+        if (options == null || $.isEmptyObject(options)) {
+            opts = this;
+        } else {
+            opts = $.extend(true, {}, this, options);
         }
-        this.shapeRenderer.draw(ctx, points, options);
+        var points = [p1, p2];
+        if (opts.shadow) {
+            this.shadowRenderer.draw(ctx, points, getShadowRendererOptions(opts));
+        }
+        this.shapeRenderer.draw(ctx, points, getShapeRendererOptions(opts));
     };
     
     $.jqplot.MarkerRenderer.prototype.drawSquare = function(x, y, ctx, fill, options) {
+        var opts;
+        if (options == null || $.isEmptyObject(options)) {
+            opts = this;
+        } else {
+            opts = $.extend(true, {}, this, options);
+        }
         var stretch = 1.0;
         var dx = this.size/2/stretch;
         var dy = this.size/2*stretch;
         var points = [[x-dx, y-dy], [x-dx, y+dy], [x+dx, y+dy], [x+dx, y-dy]];
-        if (this.shadow) {
-            this.shadowRenderer.draw(ctx, points);
+        if (opts.shadow) {
+            this.shadowRenderer.draw(ctx, points, getShadowRendererOptions(opts));
         }
-        this.shapeRenderer.draw(ctx, points, options);
+        this.shapeRenderer.draw(ctx, points, getShapeRendererOptions(opts));
     };
     
     $.jqplot.MarkerRenderer.prototype.drawCircle = function(x, y, ctx, fill, options) {
+        var opts;
+        if (options == null || $.isEmptyObject(options)) {
+            opts = this;
+        } else {
+            opts = $.extend(true, {}, this, options);
+        }
         var radius = this.size/2;
         var end = 2*Math.PI;
         var points = [x, y, radius, 0, end, true];
-        if (this.shadow) {
-            this.shadowRenderer.draw(ctx, points);
+        if (opts.shadow) {
+            this.shadowRenderer.draw(ctx, points, getShadowRendererOptions(opts));
         }
-        this.shapeRenderer.draw(ctx, points, options);
+        this.shapeRenderer.draw(ctx, points, getShapeRendererOptions(opts));
     };
     
     $.jqplot.MarkerRenderer.prototype.draw = function(x, y, ctx, options) {
@@ -189,7 +224,8 @@
             if (options.color && !options.strokeStyle) {
                 options.strokeStyle = options.color;
             }
-            switch (this.style) {
+            var style = options.style || this.style;
+            switch (style) {
                 case 'diamond':
                     this.drawDiamond(x,y,ctx, false, options);
                     break;


### PR DESCRIPTION
This patch adds a `markerOptionsCallback` option that allows a callback to be specified so as to customise the marker options for an individual point. (There is also an example page with this patch.)


![jqplot-pr-61](https://cloud.githubusercontent.com/assets/80994/13380864/b3e46160-de44-11e5-93f9-200b8861010b.png)

For example, if the values are negative, turn the marker red:

            markerOptionsCallback: function(plot, series, idx, dataPoint, gridDataPoint) {
                var opts =  { style:"diamond" };
                if (dataPoint[1] < 0) {
                    opts.color = "red";
                }
                return opts;
            }

If the point index is above 3, turn the marker yellow:

            markerOptionsCallback: function(plot, series, idx, dataPoint, gridDataPoint) {
                var opts =  {};
                if (dataPoint[0] >3) {
                    opts.color = "yellow";
                }
                return opts;
            }