### PR TITLE
Highlighting cursor

### DIFF
--- a/examples/highlighthingCursor.php
+++ b/examples/highlighthingCursor.php
@@ -1,0 +1,189 @@
+<?php 
+    $title = "Highlighthing Cursor";
+    // $plotTargets = array('chart1');
+?>
+<?php include "opener.php"; ?>
+
+<!-- Example scripts go here -->
+
+<p class="text">This has a vertical cursor and highlights all the points that are neighbours of that cursor.</p>
+<div id="chart1" style="margin:20px;height:440px; width:640px;"></div>
+<p class="text">This is the same example, but also uses the "update" callback to display the values in a separate table.</p>
+<table id="values2" style="height: 80px">
+</table>
+<div id="chart2" style="margin:20px;height:440px; width:640px;"></div>
+
+
+<script type="text/javascript">
+var data = [];
+var baseOptions;
+
+$(document).ready(function(){
+    var series1 = [];
+    var series2 = [];
+    var i;
+    for (i = 0; i < 300; i++) {
+        var x = 1.5 * i;
+        series1.push([x, 10+2*Math.sin(x/10.0)]);
+        series2.push([x, 5*Math.exp(-(x-400)*(x-400)/300)]);
+    }
+    // This gap is just to test what happens when there is a gap.
+    for (i = 450; i < 600; i++) {
+        var x = 1.5 * i;
+        series1.push([x, 10+2*Math.sin(x/10.0)]);
+        series2.push([x, 5*Math.exp(-(x-400)*(x-400)/300)]);
+    }
+    data.push(series1);
+    data.push(series2);
+    
+    baseOptions = {
+        seriesDefaults: {
+            lineWidth: 1,
+            markerOptions: {
+                size: 0
+            }
+        },
+        series: {
+            0: {
+                label: "Test A",
+                yaxis: 'yaxis'
+            },
+            1: {
+                label: "Test B",
+                yaxis: 'y2axis'
+            }
+        },
+        axesDefaults: {
+            labelRenderer: $.jqplot.CanvasAxisLabelRenderer,
+            labelOptions:{
+                fontFamily: 'Helvetica',
+                fontSize: '12pt'
+            },
+            rendererOptions: {
+                alignTicks: true
+            },
+            tickRenderer: $.jqplot.CanvasAxisTickRenderer
+        },
+        axes: {
+            xaxis: {
+                tickOptions: {
+                    angle:-15,
+                    fontSize: '9pt',
+                    labelPosition: 'middle'
+                }
+            },
+            yaxis: {
+                tickOptions: {
+                    angle:-15,
+                    fontSize: '9pt',
+                    labelPosition: 'middle'
+                }
+            },
+            y2axis: {
+                tickOptions: {
+                    angle:-15,
+                    fontSize: '9pt',
+                    labelPosition: 'middle'
+                }
+            }
+        },
+        legend: {
+            renderer: $.jqplot.EnhancedLegendRenderer,
+            show: true,
+            showLabels: true,
+            rendererOptions: {
+                numberColumns: 4,
+                showLineStyle: true,
+                showMarkerStyle: true
+            },
+            placement: 'outsideGrid',
+            location: 's',
+            shrinkGrid: true
+        },
+        highlighter: {
+            sizeAdjust: 10,
+            show: false
+        },
+        highlightingCursor: {
+            show: true
+        },
+        cursor:{
+            show: true,
+            zoom: true,
+            showTooltip: false,
+            constrainZoomTo: 'x',
+            autoscaleConstraint: true,
+            showVerticalLine: true
+        } 
+    };
+});
+</script>
+
+<script class="code" type="text/javascript">
+$(document).ready(function(){
+    var options = $.extend(true, {}, baseOptions);
+    plot1 = $.jqplot ('chart1', data, options);
+});
+</script>
+
+<script class="code" type="text/javascript">
+// <![CDATA[
+$(document).ready(function(){
+    var options = $.extend(true, {}, baseOptions);
+    options.highlightingCursor.update = function(event, action, gridpos, datapos, seriesDataPoints, plot) {
+        $('#values2').empty();
+        if (action == 'move' && seriesDataPoints != null) {
+            var xAxes = [];
+            var xAxesData = [];
+            $.each(seriesDataPoints, function(idx, dataPoint) {
+                if (dataPoint != null) {
+                    var s = plot.series[dataPoint.seriesIndex];
+                    if (s.show) {
+                        var row = $("<tr />");
+                        row.append($("<th />").text(s.label));
+                        row.append($("<td />").text(dataPoint.data[1]));
+                        $('#values2').append(row);
+                        if ($.inArray(s.xaxis, xAxes) < 0) {
+                            xAxes.unshift(s.xaxis);
+                            xAxesData.unshift([s.xaxis, dataPoint.data[0]]);
+                        }
+                    }
+                }
+            });
+            $.each(xAxesData, function(idx, axisData) {
+                var row = $("<tr />");
+                var label = plot.axes[axisData[0]].label;
+                if (label == null) { label = 'X'; }
+                row.append($("<th />").text(label));
+                row.append($("<td />").text(axisData[1]));
+                $('#values2').prepend(row);
+            });
+        }
+    };
+    plot2 = $.jqplot ('chart2', data, options);
+});
+// ]]>
+</script>
+
+
+<!-- End example scripts -->
+
+<!-- Don't touch this! -->
+
+<?php include "commonScripts.html" ?>
+
+<!-- End Don't touch this! -->
+
+<!-- Additional plugins go here -->
+
+  <script class="include" type="text/javascript" src="../src/plugins/jqplot.canvasTextRenderer.js"></script>
+  <script class="include" type="text/javascript" src="../src/plugins/jqplot.canvasAxisLabelRenderer.js"></script>
+  <script class="include" type="text/javascript" src="../src/plugins/jqplot.canvasAxisTickRenderer.js"></script>
+  <script class="include" type="text/javascript" src="../src/plugins/jqplot.cursor.js"></script>
+  <script class="include" type="text/javascript" src="../src/plugins/jqplot.enhancedLegendRenderer.js"></script>
+  <script class="include" type="text/javascript" src="../src/plugins/jqplot.highlighter.js"></script>
+  <script class="include" type="text/javascript" src="../src/plugins/jqplot.highlightingCursor.js"></script>
+
+<!-- End additional plugins -->
+
+<?php include "closer.php"; ?>

--- a/examples/highlighthingCursor.php
+++ b/examples/highlighthingCursor.php
@@ -8,7 +8,10 @@
 
 <p class="text">This has a vertical cursor and highlights all the points that are neighbours of that cursor.</p>
 <div id="chart1" style="margin:20px;height:440px; width:640px;"></div>
-<p class="text">This is the same example, but also uses the "update" callback to display the values in a separate table.</p>
+<p class="text">This is the same example, but also uses the "update" callback to display the values in a separate table.
+
+In this example, you can also click to freeze the cursor at the current position: the cursor will remain at that position even if you move the mouse.
+The cursor can be released by clicking again.</p>
 <table id="values2" style="height: 80px">
 </table>
 <div id="chart2" style="margin:20px;height:440px; width:640px;"></div>
@@ -105,15 +108,15 @@ $(document).ready(function(){
             show: false
         },
         highlightingCursor: {
-            show: true
+            show: true,
+            showVerticalLine: true
         },
         cursor:{
             show: true,
             zoom: true,
             showTooltip: false,
             constrainZoomTo: 'x',
-            autoscaleConstraint: true,
-            showVerticalLine: true
+            autoscaleConstraint: true
         } 
     };
 });
@@ -130,6 +133,9 @@ $(document).ready(function(){
 // <![CDATA[
 $(document).ready(function(){
     var options = $.extend(true, {}, baseOptions);
+	
+	options.highlightingCursor.freezeCursorOnClick = true;
+	
     options.highlightingCursor.update = function(event, action, gridpos, datapos, seriesDataPoints, plot) {
         $('#values2').empty();
         if (action == 'move' && seriesDataPoints != null) {

--- a/src/plugins/jqplot.highlightingCursor.js
+++ b/src/plugins/jqplot.highlightingCursor.js
@@ -1,0 +1,137 @@
+/**
+ * jqPlot
+ * Pure JavaScript plotting plugin using jQuery
+ *
+ * Version: @VERSION
+ * Revision: @REVISION
+ *
+ * Copyright (c) 2009-2013 Chris Leonello
+ * jqPlot is currently available for use in all personal or commercial projects 
+ * under both the MIT (http://www.opensource.org/licenses/mit-license.php) and GPL 
+ * version 2.0 (http://www.gnu.org/licenses/gpl-2.0.html) licenses. This means that you can 
+ * choose the license that best suits your project and use it accordingly. 
+ *
+ * Although not required, the author would appreciate an email letting him 
+ * know of any substantial use of jqPlot.  You can reach the author at: 
+ * chris at jqplot dot com or see http://www.jqplot.com/info.php .
+ *
+ * If you are feeling kind and generous, consider supporting the project by
+ * making a donation at: http://www.jqplot.com/donate.php .
+ *
+ * 
+ */
+(function($) {
+    $.jqplot.eventListenerHooks.push(['jqplotMouseMove', handleMove]);
+    $.jqplot.eventListenerHooks.push(['jqplotMouseEnter', handleEnter]);
+    $.jqplot.eventListenerHooks.push(['jqplotMouseLeave', handleLeave]);
+    
+    /**
+     */
+    $.jqplot.HighlightingCursor = function(options) {
+        $.extend(true, this, options);
+    };
+    
+    // called with scope of plot
+    $.jqplot.HighlightingCursor.init = function (target, data, opts) {
+        var options = opts || {};
+        // add a highlighter attribute to the plot
+        if (this.plugins.highlighter == null) {
+            this.plugins.highlighter = new $.jqplot.Highlighter(options.highlighter);
+        }
+        this.plugins.highlightingCursor = new $.jqplot.HighlightingCursor(options.highlightingCursor);
+    };
+    
+    // called within context of plot
+    // create a canvas which we can draw on.
+    // insert it before the eventCanvas, so eventCanvas will still capture events.
+    $.jqplot.HighlightingCursor.postPlotDraw = function() {
+    };
+    
+    $.jqplot.preInitHooks.push($.jqplot.HighlightingCursor.init);
+    $.jqplot.postDrawHooks.push($.jqplot.HighlightingCursor.postPlotDraw);
+    
+    // This is the draw function from the $.jqplot.Highlighter plugin.
+    function draw(plot, neighbor) {
+        var hl = plot.plugins.highlighter;
+        var s = plot.series[neighbor.seriesIndex];
+        var smr = s.markerRenderer;
+        var mr = hl.markerRenderer;
+        mr.style = smr.style;
+        mr.lineWidth = smr.lineWidth + hl.lineWidthAdjust;
+        mr.size = smr.size + hl.sizeAdjust;
+        var rgba = $.jqplot.getColorComponents(smr.color);
+        var newrgb = [rgba[0], rgba[1], rgba[2]];
+        var alpha = (rgba[3] >= 0.6) ? rgba[3]*0.6 : rgba[3]*(2-rgba[3]);
+        mr.color = 'rgba('+newrgb[0]+','+newrgb[1]+','+newrgb[2]+','+alpha+')';
+        mr.init();
+        var x_pos = s.gridData[neighbor.pointIndex][0];
+        var y_pos = s.gridData[neighbor.pointIndex][1];
+        // Adjusting with s._barNudge
+        if (s.renderer.constructor == $.jqplot.BarRenderer) {
+            if (s.barDirection == "vertical") {
+                x_pos += s._barNudge;
+            }
+            else {
+                y_pos -= s._barNudge;
+            }
+        }
+        mr.draw(x_pos, y_pos, hl.highlightCanvas._ctx);
+    }
+    
+    function handleEnter(ev, gridpos, datapos, neighbor, plot) {
+        if (plot.plugins.highlightingCursor.update != null) {
+            plot.plugins.highlightingCursor.update(ev, 'enter', gridpos, datapos, null, plot);
+        }
+    }
+    
+    function handleLeave(ev, gridpos, datapos, neighbor, plot) {
+        if (plot.plugins.highlightingCursor.update != null) {
+            plot.plugins.highlightingCursor.update(ev, 'leave', gridpos, datapos, null, plot);
+        }
+    }
+    
+    function handleMove(ev, gridpos, datapos, neighbor, plot) {
+        var seriesDataPoints = [];
+        $.each(plot.series, function(seriesIdx, series) {
+            var candidateDataPoint = null;
+            var prevDist = null;
+            var threshold = series.markerRenderer.size/2+series.neighborThreshold;
+            threshold = (threshold > 0) ? threshold : 0;
+            for (var j = 0; j < series.gridData.length; j++) {
+                var p = series.gridData[j];
+                var dist = Math.abs(p[0] - gridpos.x);
+                if (dist <= threshold) {
+                   if (prevDist == null || dist <= prevDist) {
+                       candidateDataPoint = {
+                           seriesIndex: seriesIdx,
+                           pointIndex: j,
+                           data: series.data[j],
+                           gridData: p
+                       };
+                       prevDist = dist;
+                   }
+                } else if (prevDist != null) {
+                   break;
+                }
+            }
+            seriesDataPoints[seriesIdx] = candidateDataPoint;
+        });
+      
+        if (plot.plugins.highlightingCursor.show) {
+            var hl = plot.plugins.highlighter;
+            var ctx = hl.highlightCanvas._ctx;
+            ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+            $.each(seriesDataPoints, function(idx, neighbor) {
+                if (neighbor != null
+                        && plot.series[neighbor.seriesIndex].showHighlight
+                        && plot.series[neighbor.seriesIndex].show) {
+                    draw(plot, neighbor);
+                }
+            });
+        }
+        
+        if (plot.plugins.highlightingCursor.update != null) {
+            plot.plugins.highlightingCursor.update(ev, 'move', gridpos, datapos, seriesDataPoints, plot);
+        }
+    }
+})(jQuery);


### PR DESCRIPTION
This adds a new plugin for a highlighting cursor.

The main difference with the existing cursor and highlighter is that it will activate the markers for all neighbouring points around the cursor, whereas the normal highlighter would only activate the marker on the point close to where the mouse pointer is (not the vertical cursor).

![jqplot-pr-62](https://cloud.githubusercontent.com/assets/80994/13381283/23743c84-de50-11e5-83c4-d669c3eeabc4.png)

This also comes with an `update` callback, which can be used to update other parts of the page when the cursor has been moved.
There is also an option that gives the user the ability to "freeze" the cursor at a position of interest by clicking (the mouse cursor can then be moved without losing that position).

This pull request comes with additional examples.