### PR TITLE
Using a date axis renderer sometimes distorts the data

### DIFF
--- a/src/plugins/jqplot.dateAxisRenderer.js
+++ b/src/plugins/jqplot.dateAxisRenderer.js
@@ -204,8 +204,8 @@
             for (var j=0; j<d.length; j++) { 
                 if (this.name == 'xaxis' || this.name == 'x2axis') {
                     d[j][0] = new $.jsDate(d[j][0]).getTime();
-                    pd[j][0] = new $.jsDate(d[j][0]).getTime();
-                    sd[j][0] = new $.jsDate(d[j][0]).getTime();
+                    pd[j][0] = new $.jsDate(pd[j][0]).getTime();
+                    sd[j][0] = new $.jsDate(sd[j][0]).getTime();
                     if ((d[j][0] != null && d[j][0] < db.min) || db.min == null) {
                         db.min = d[j][0];
                     }
@@ -227,8 +227,8 @@
                 }              
                 else {
                     d[j][1] = new $.jsDate(d[j][1]).getTime();
-                    pd[j][1] = new $.jsDate(d[j][1]).getTime();
-                    sd[j][1] = new $.jsDate(d[j][1]).getTime();
+                    pd[j][1] = new $.jsDate(pd[j][1]).getTime();
+                    sd[j][1] = new $.jsDate(sd[j][1]).getTime();
                     if ((d[j][1] != null && d[j][1] < db.min) || db.min == null) {
                         db.min = d[j][1];
                     }


### PR DESCRIPTION
(Same as [issue 611 on Bitbucket](https://bitbucket.org/cleonello/jqplot/issues/611).)

The attached image shows two examples using the same data (input in ms since Unix Epoch). When using the plain linear axis, the points are rendered as expected, but when using the date axis, some artificial variations are introduced. (On larger datasets, it can actually shift part of the plots, when multiple series would otherwise be synchronised.)

![jqplot-pr-63](https://cloud.githubusercontent.com/assets/80994/13394443/428dd66c-dee0-11e5-8ca9-b5e3935099e1.png)

