### PR TITLE
outsideGrid south legends centering doesn't take into account axes shift

### DIFF
--- a/src/jqplot.core.js
+++ b/src/jqplot.core.js
@@ -3051,10 +3051,6 @@
                 
                 if (this.legend.placement === 'outsideGrid') {
                     legendPadding = {top:this.title.getHeight(), left: 0, right: 0, bottom: 0};
-                    if (this.legend.location === 's') {
-                        legendPadding.left = this._gridPadding.left;
-                        legendPadding.right = this._gridPadding.right;
-                    }
                 }
                 
                 ax.xaxis.pack({position:'absolute', bottom:this._gridPadding.bottom - ax.xaxis.getHeight(), left:0, width:this._width}, {min:this._gridPadding.left, max:this._width - this._gridPadding.right});


### PR DESCRIPTION
(This is the same problem as [Bitbucket issue 623](https://bitbucket.org/cleonello/jqplot/issues/623) and fix suggested in [Bitbucket PR 26](https://bitbucket.org/cleonello/jqplot/pull-requests/26).)


When using `outsideGrid` placement for the legend located south, the legend box is centred on the middle of the graph area, excluding the space taken by the Y-axes.

This can lead to legend boxes overflowing on the left, when there is a large number of Y-axes (particularly with the enhanced legend renderer).

The attached screenshot illustrates the problem. The legend box is cut off on the left, hitting the left end of the browser window, whereas there would have been enough space on the right-hand side to display the legend box on an area that includes the space taken by the Y-axes. (It's not cut off when viewing as an image, but it's still shifted on the side.)

![jqplot-pr-64](https://cloud.githubusercontent.com/assets/80994/13395325/0793502c-dee6-11e5-8382-1b99b27e02df.png)

Here is the result after the patch:

![jqplot-pr-64-b](https://cloud.githubusercontent.com/assets/80994/13395426/8965fd98-dee6-11e5-98e7-5eb1fb0197de.png)


Here is an example file (renamed to `.txt` for it to be attached here): 
[legends.php.txt](https://github.com/jqPlot/jqPlot/files/150947/legends.php.txt)
