### PR TITLE
Hide canvasOverlay tooltips when saving to image.

### DIFF
--- a/src/jqplot.toImage.js
+++ b/src/jqplot.toImage.js
@@ -232,7 +232,7 @@
 
             // somehow in here, for divs within divs, the width of the inner div should be used instead of the canvas.
 
-            if ((tagname == 'div' || tagname == 'span') && !$(el).hasClass('jqplot-highlighter-tooltip')) {
+            if ((tagname == 'div' || tagname == 'span') && !$(el).hasClass('jqplot-highlighter-tooltip') && !$(el).hasClass('jqplot-canvasOverlay-tooltip')) {
                 $(el).children().each(function() {
                     _jqpToImage(this, left, top);
                 });


### PR DESCRIPTION
`jqplot.toImage.js` was hiding the tooltips coming from the highlighter plugin, but not those from the canvasOverlay plugin. This patch fixes also hides those coming from canvasOverlay.

In the long term, it might be better to add a second class (e.g. `jqplot-toimage-hide`) to all tooltips or other elements to hide when rendering to an image, so as not to have this reference to plugin code from the core code. (I could try to improve this pull request accordingly depending on the feedback.)