### PR TITLE
bugfix on jqplot.dragable.js

### DIFF
--- a/src/plugins/jqplot.dragable.js
+++ b/src/plugins/jqplot.dragable.js
@@ -152,7 +152,7 @@
             else {
                 drag._gridData[0] = [x, y];
             }
-            plot.series[dp.seriesIndex].draw(dc._ctx, {gridData:drag._gridData, shadow:false, preventJqPlotSeriesDrawTrigger:true, color:drag.color, markerOptions:{color:drag.color, shadow:false}, trendline:{show:false}});
+            plot.series[dp.seriesIndex].draw(dc._ctx, {gridData:drag._gridData, shadow:false, preventJqPlotSeriesDrawTrigger:true, color:drag.color, markerOptions:{color:drag.color, shadow:false}, trendline:{show:false}}, plot);
             plot.target.trigger('jqplotSeriesPointChange', [dp.seriesIndex, dp.pointIndex, [xu,yu], [x,y]]);
         }
         else if (neighbor != null) {


### PR DESCRIPTION
Hello, this fixes the drag and drop when used with the bubble renderer: it was generating an error, making it slow. 