### PR TITLE
Funnel Chart Misaligned in Canvas Area in 1.0.9

### DIFF
--- a/src/plugins/jqplot.funnelRenderer.js
+++ b/src/plugins/jqplot.funnelRenderer.js
@@ -350,8 +350,8 @@
         var shadow = (opts.shadow != undefined) ? opts.shadow : this.shadow;
         var showLine = (opts.showLine != undefined) ? opts.showLine : this.showLine;
         var fill = (opts.fill != undefined) ? opts.fill : this.fill;
-        var cw = ctx.canvas.width;
-        var ch = ctx.canvas.height;
+        var cw =  parseInt(ctx.canvas.style.width);
+        var ch =  parseInt(ctx.canvas.style.height);
         this._bases[0] = cw - loff - roff;
         var ltot = this._length = ch - toff - boff;
 


### PR DESCRIPTION
… big in canvas and broken.

Issue Detail:- With Version 1.0.9, funnelchart plot is very big in size and going out of canvas area.This happens only if devicepixelratio is >1 in any browser and in firefox whose pixelratio is -1.

Analysis:- Observed that in jquery.jqplot.js InitCanvas method,Canvas is set based on device pixelratio.But in plugin file funnelrenderer.js CSS Canvas width and height is not considered for plotting funnel chart within canvas.This is causing issue.
This was handled only in pierenderer in version 1.0.9.

Solution:- Applied CSS Canvas width and height in draw function of funnelrenderer. Chart comes-up fine irrespective of device pixel ratio in all browsers.