### PR TITLE
Fill all pie chart when hidding some slices of checked elements in the legend

### DIFF
--- a/src/plugins/jqplot.pieRenderer.js
+++ b/src/plugins/jqplot.pieRenderer.js
@@ -236,6 +236,23 @@
     };
     
     $.jqplot.PieRenderer.prototype.makeGridData = function(data, plot) {
+
+        var hdt = document.getElementsByClassName("jqplot-table-legend-label jqplot-seriesToggle jqplot-series-hidden");
+
+        var ndt = this.data.map(function(arr) {
+                    return arr.slice();
+        });
+
+        if (hdt[0] != null) {
+            for(i=0;i<hdt.length;i++){
+                for(j=0;j<ndt.length;j++){
+                    if(hdt[i].innerText == ndt[j][0]){
+                        ndt[j][1] = 0;
+                    }
+                }
+            }
+        }
+
         var stack = [];
         var td = [];
         var tot = 0;
@@ -247,18 +264,18 @@
                 // we have data, O.K. to draw.
                 this._drawData = true;
             }
-            stack.push(data[i][1]);
-            td.push([data[i][0]]);
+            stack.push(ndt[i][1]);
+            td.push([ndt[i][0]]);
             if (i>0) {
                 stack[i] += stack[i-1];
             }
-            tot += data[i][1];
+            tot += ndt[i][1];
         }
         var fact = Math.PI*2/stack[stack.length - 1];
         
         for (var i=0; i<stack.length; i++) {
             td[i][1] = stack[i] * fact;
-            td[i][2] = data[i][1]/tot;
+            td[i][2] = ndt[i][1]/tot;
         }
         return td;
     };


### PR DESCRIPTION
Fix issue #130 

it makes changes to function makeGridData in pieRenderer.js plugin..
It's not necessary changing enhancedPieLegendRenderer.js plugin, although, it makes sense and is useful along with the use of this plugin.