### PR TITLE
reverse order delete mark

### DIFF
--- a/src/plugins/jqplot.enhancedLegendRenderer.js
+++ b/src/plugins/jqplot.enhancedLegendRenderer.js
@@ -202,11 +202,11 @@
                                     }
                                 } 
                                 if (this.showSwatches) {
-                                    td1.bind('click', {series:s, speed:speed, plot: plot, replot:this.seriesToggleReplot}, handleToggle);
+                                    td1.bind('click', {series:s, speed:speed, plot: plot, replot:this.seriesToggleReplot, reverse:reverse}, handleToggle);
                                     td1.addClass('jqplot-seriesToggle');
                                 }
                                 if (this.showLabels)  {
-                                    td2.bind('click', {series:s, speed:speed, plot: plot, replot:this.seriesToggleReplot}, handleToggle);
+                                    td2.bind('click', {series:s, speed:speed, plot: plot, replot:this.seriesToggleReplot, reverse:reverse}, handleToggle);
                                     td2.addClass('jqplot-seriesToggle');
                                 }
 
@@ -235,6 +235,7 @@
             replot = d.replot,
             plot = d.plot,
             speed = d.speed,
+            reverse = reverse,
             sidx = s.index,
             showing = false;
 

--- a/src/plugins/jqplot.enhancedLegendRenderer.js
+++ b/src/plugins/jqplot.enhancedLegendRenderer.js
@@ -235,7 +235,7 @@
             replot = d.replot,
             plot = d.plot,
             speed = d.speed,
-            reverse = reverse,
+            reverse = d.reverse,
             sidx = s.index,
             showing = false;
 
@@ -268,24 +268,28 @@
             }
 
             else {
+                sidx1 = sidx;
+                if(reverse) {
+                    sidx1 = plot.series.length - 1 - sidx;
+                }
                 var s = plot.series[sidx];
 
                 if (s.canvas._elem.is(':hidden') || !s.show) {
                     // Not sure if there is a better way to check for showSwatches and showLabels === true.
                     // Test for "undefined" since default values for both showSwatches and showLables is true.
                     if (typeof plot.options.legend.showSwatches === 'undefined' || plot.options.legend.showSwatches === true) {
-                        plot.legend._elem.find('td').eq(sidx * 2).addClass('jqplot-series-hidden');
+                        plot.legend._elem.find('td').eq(sidx1 * 2).addClass('jqplot-series-hidden');
                     }
                     if (typeof plot.options.legend.showLabels === 'undefined' || plot.options.legend.showLabels === true) {
-                        plot.legend._elem.find('td').eq((sidx * 2) + 1).addClass('jqplot-series-hidden');
+                        plot.legend._elem.find('td').eq((sidx1 * 2) + 1).addClass('jqplot-series-hidden');
                     }
                 }
                 else {
                     if (typeof plot.options.legend.showSwatches === 'undefined' || plot.options.legend.showSwatches === true) {
-                        plot.legend._elem.find('td').eq(sidx * 2).removeClass('jqplot-series-hidden');
+                        plot.legend._elem.find('td').eq(sidx1 * 2).removeClass('jqplot-series-hidden');
                     }
                     if (typeof plot.options.legend.showLabels === 'undefined' || plot.options.legend.showLabels === true) {
-                        plot.legend._elem.find('td').eq((sidx * 2) + 1).removeClass('jqplot-series-hidden');
+                        plot.legend._elem.find('td').eq((sidx1 * 2) + 1).removeClass('jqplot-series-hidden');
                     }
                 }
 


### PR DESCRIPTION
When we click legend item in stacked bar chart legend, delete mark appears in reverse order.
This is a bug.
I debugged it.