### PR TITLE
Fix for IE drag/zoom error

### DIFF
--- a/src/plugins/jqplot.cursor.js
+++ b/src/plugins/jqplot.cursor.js
@@ -921,7 +921,7 @@
                 document.selection.empty();
             }
             else if (sel && !sel().isCollapsed) {
-                sel().collapse();
+                sel().collapse(ev.currentTarget, 0);
             }
             drawZoomBox.call(c);
             ctx = null;


### PR DESCRIPTION
Fixes Internet Explorer bug, when cursor leaves the canvas while dragging and zooming.