### PR TITLE
Avoid tool-tip off screen

### DIFF
--- a/src/plugins/jqplot.highlighter.js
+++ b/src/plugins/jqplot.highlighter.js
@@ -408,7 +408,7 @@
     	        y -= series._barNudge;
     	    }
     	}
-        elem.css('left', x);
+        elem.css('left', x < 0 ? 0: x);
         elem.css('top', y);
         if (opts.fadeTooltip) {
             // Fix for stacked up animations.  Thnanks Trevor!


### PR DESCRIPTION
Prevent left most tool-tip from appearing off screen.

When using jqplot within some existing applications. Often the left most tooltip is returned as a negative x coordinate value e.g. "left: -75.25px".

This causes tool-tips to appear out of frame. So capping left at 0 will prevent these issues.