### PR TITLE
Gauge is not rendered correctly when devicePixelRatio > 1

### DIFF
--- a/src/plugins/jqplot.meterGaugeRenderer.js
+++ b/src/plugins/jqplot.meterGaugeRenderer.js
@@ -371,8 +371,8 @@
         var shadow = (opts.shadow != undefined) ? opts.shadow : this.shadow;
         var showLine = (opts.showLine != undefined) ? opts.showLine : this.showLine;
         var fill = (opts.fill != undefined) ? opts.fill : this.fill;
-        var cw = ctx.canvas.width;
-        var ch = ctx.canvas.height;
+        var cw = parseInt(ctx.canvas.style.width);
+        var ch = parseInt(ctx.canvas.style.height);
         if (this.padding == null) {
             this.padding = Math.round(Math.min(cw, ch)/30);
         }


### PR DESCRIPTION
I applied the same change here as was previously applied in funnel renderer