### PR TITLE
Performance optimization for CategoryAxisRenderer: Avoid Forced Layouts

### DIFF
--- a/src/plugins/jqplot.categoryAxisRenderer.js
+++ b/src/plugins/jqplot.categoryAxisRenderer.js
@@ -546,9 +546,12 @@
                         else {
                             shim = -t.getWidth()/2;
                         }
-                        var val = this.u2p(t.value) + shim + 'px';
-                        t._elem.css('left', val);
-                        t.pack();
+
+			if (shim != 0) {
+                            var val = this.u2p(t.value) + shim + 'px';
+                            t._elem.css('left', val);
+                            t.pack();
+                        }
                     }
                 }
                 


### PR DESCRIPTION
I was hitting a performance issue, where a graph redraw with ~12000 elements took over 20 seconds to render on Firefox and Chrome. With the new optimization, it came down to a few seconds.
With their performance profilers, i traced this down to CategoryAxisRenderer. The combination of setting CSS ('left'), and getWidth() is triggering a layout recalculation for each of the 12000 elements.
This can be cut down to only a handful, when those elements with 0 width do not get positioned.

This could also be applicable to other AxisRenderers. There might be even a better way to ignore those axis ticks that are not rendererd anyway.

I didn't test beyond my application, so i can't say for sure that this code change is sound.