### PR TITLE
Preventing plot selection when double-clicking (e.g. for zoom reset).

### DIFF
--- a/src/jqplot.lineRenderer.js
+++ b/src/jqplot.lineRenderer.js
@@ -1210,6 +1210,16 @@
     }
     
     function handleClick(ev, gridpos, datapos, neighbor, plot) {
+        var sel = window.getSelection;
+        if (document.selection && document.selection.empty)
+        {
+            document.selection.empty();
+        }
+        else if (sel && !sel().isCollapsed) {
+            var selection = sel();
+            selection.collapse(selection.anchorNode, selection.anchorOffset);
+        }
+        
         if (neighbor) {
             var ins = [neighbor.seriesIndex, neighbor.pointIndex, neighbor.data];
             var evt = jQuery.Event('jqplotDataClick');
@@ -1221,6 +1231,16 @@
     }
     
     function handleRightClick(ev, gridpos, datapos, neighbor, plot) {
+        var sel = window.getSelection;
+        if (document.selection && document.selection.empty)
+        {
+            document.selection.empty();
+        }
+        else if (sel && !sel().isCollapsed) {
+            var selection = sel();
+            selection.collapse(selection.anchorNode, selection.anchorOffset);
+        }
+        
         if (neighbor) {
             var ins = [neighbor.seriesIndex, neighbor.pointIndex, neighbor.data];
             var idx = plot.plugins.lineRenderer.highlightedSeriesIndex;


### PR DESCRIPTION
If you double-click to reset the zoom, the text that belongs to the plot will often be selected, since the browser also treats this as a double-click that selects the surrounding area.

For example on http://www.jqplot.com/examples/zoom1.php

If you zoom in and then double click to reset the zoom, some of the text is selected.

![image](https://github.com/jqPlot/jqPlot/assets/80994/eaf84c29-65aa-4fd6-ab9b-b6b6353a9d0b)

This patch prevents this.