### PR TITLE
Added support for canvas contextAttributes, defaults to willReadFrequently=true

### DIFF
--- a/src/jqplot.core.js
+++ b/src/jqplot.core.js
@@ -296,7 +296,7 @@
                 return window.G_vmlCanvasManager.initElement(canvas);
             }
 
-            var cctx = canvas.getContext('2d');
+            var cctx = canvas.getContext('2d', $.jqplot.config.canvasContextAttributes);
 
             var canvasBackingScale = 1;
             if (window.devicePixelRatio > 1 && (cctx.webkitBackingStorePixelRatio === undefined || 
@@ -376,7 +376,8 @@
         gapLength: 4,
         dotGapLength: 2.5,
         srcLocation: 'jqplot/src/',
-        pluginLocation: 'jqplot/src/plugins/'
+        pluginLocation: 'jqplot/src/plugins/',
+        canvasContextAttributes: { willReadFrequently: true }
     };
     
     


### PR DESCRIPTION
This adds a new option to pass [context attributes](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext#contextattributes) when initialising the canvas context:

```
$.jqplot.config.canvasContextAttributes
```

This is also now set by default to `{ willReadFrequently: true }`, to fix #204.