### PR TITLE
Ant build fixes

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -12,7 +12,7 @@
     <property file="dist.props" />
     
     <!-- misc. properties -->
-    <property description="YUICompressor" name="YUICompressor" value="extras/yuicompressor-2.4.7.jar" />
+    <property description="YUICompressor" name="YUICompressor" value="extras/yuicompressor-2.4.8.jar" />
     <loadfile description="Version to build" property="version" srcfile="version.txt">
         <filterchain>
             <striplinebreaks/>

--- a/build.xml
+++ b/build.xml
@@ -13,7 +13,11 @@
     
     <!-- misc. properties -->
     <property description="YUICompressor" name="YUICompressor" value="extras/yuicompressor-2.4.7.jar" />
-    <loadfile description="Version to build" property="version" srcfile="version.txt" />
+    <loadfile description="Version to build" property="version" srcfile="version.txt">
+        <filterchain>
+            <striplinebreaks/>
+        </filterchain>
+    </loadfile>
     <loadfile description="Copyright and license" property="copyright" srcfile="copyright.txt" />
     <loadfile description="Minified copyright" property="copyrightmin" srcfile="copyright_min.txt" />
     <condition property="ND" value="${basedir}/extras/NaturalDocs/NaturalDocs.bat" else="${basedir}/extras/NaturalDocs/NaturalDocs">


### PR DESCRIPTION
I realise the new way of building jqPlot is with Grunt, but the old Ant `build.xml` file is there and mostly works, except for a small mistake due to on EOL in `version.txt`.

```
    [echo] minifying file: jquery.jqplot.js
    [apply]
    [apply] [ERROR] 248:29:unterminated string literal
    [apply]
    [apply] [ERROR] 248:29:syntax error
    [apply]
    [apply] [ERROR] 249:2:unterminated string literal
    [apply]
    [apply] [ERROR] 1:0:Compilation produced 3 syntax errors.
    [apply] org.mozilla.javascript.EvaluatorException: Compilation produced 3 syntax errors.
    [apply]     at com.yahoo.platform.yui.compressor.YUICompressor$1.runtimeError(YUICompressor.java:154)
    [apply]     at org.mozilla.javascript.Parser.parse(Parser.java:392)
    [apply]     at org.mozilla.javascript.Parser.parse(Parser.java:337)
    [apply]     at com.yahoo.platform.yui.compressor.JavaScriptCompressor.parse(JavaScriptCompressor.java:312)
    [apply]     at com.yahoo.platform.yui.compressor.JavaScriptCompressor.<init>(JavaScriptCompressor.java:533)
    [apply]     at com.yahoo.platform.yui.compressor.YUICompressor.main(YUICompressor.java:131)
    [apply]     at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    [apply]     at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
    [apply]     at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    [apply]     at java.base/java.lang.reflect.Method.invoke(Method.java:568)
    [apply]     at com.yahoo.platform.yui.compressor.Bootstrap.main(Bootstrap.java:21)
    [apply] Result: 2
```

This is due to the EOL in `version.txt` which is re-inserted in the build output (`build/jquery.jqplot.js`):

```javascript
    $.jqplot.version = "1.0.9
";
```

This PR fixes this issue by filtering out the EOL in the Ant file, and also upgrades to the latest YUI compressor (which still needs to be downloaded separately).