### PR TITLE
Fix for issue #186: jqplot to image: legend swatches overlapping in jQuery > 3.2.1.

### DIFF
--- a/src/jqplot.toImage.js
+++ b/src/jqplot.toImage.js
@@ -261,8 +261,14 @@
                     // get the first div and stroke it
                     var elem = $(this);
                     newContext.strokeStyle = elem.css('border-top-color');
-                    var l = left + elem.position().left;
-                    var t = top + elem.position().top;
+                    var elOffset = $(el).offset();
+                    var rowOffset = elem.parent().offset();
+                    var customPosition = {
+                        top: rowOffset.top - elOffset.top + parseInt(elem.parent().css('padding-top'), 0),
+                        left: rowOffset.left - elOffset.left + parseInt(elem.parent().css('padding-left'), 0)
+                    };
+                    var l = left + customPosition.left;
+                    var t = top + customPosition.top;
                     newContext.strokeRect(l, t, elem.innerWidth(), elem.innerHeight());
 
                     // now fill the swatch


### PR DESCRIPTION
This is a PR for the fix suggested in issue #186 by @GitHubUser4234 and @robertoferreirajrr.
It seems to work both with jQuery 1.9.1 and 3.7.1, thank you.

(This is just a PR for convenience. I'm quite happy to withdraw this PR the original participants to issue #186 want to create one as authors.)
